### PR TITLE
Fix angular-cubes dependency and add travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,6 @@ before_script:
   - nosetests --version
 script:
   - nosetests --with-coverage --cover-package=spendb
-  # - karma start --single-run --browsers PhantomJS karma.conf.js
+  - karma start --single-run --browsers PhantomJS karma.conf.js
 after_success:
   - coveralls

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -30,7 +30,7 @@ module.exports = function(config) {
       'spendb.ui/vendor/ng-file-upload/ng-file-upload-shim.js',
       'spendb.ui/vendor/ng-file-upload/ng-file-upload.js',
       'spendb.ui/vendor/angular-bootstrap/ui-bootstrap-tpls.min.js',
-      'spendb.ui/vendor/angular-cubes/build/angular-cubes.js',
+      'spendb.ui/vendor/angular-cubes/dist/angular-cubes.js',
       'node_modules/angular-mocks/angular-mocks.js',
       'spendb.ui/tests/js/helper.js',
       'spendb.ui/js/app.js',


### PR DESCRIPTION
## What does this PR do?
Fixes the angular-cubes dependency in karma. 
Since angular-cubes changed the build system here:
https://github.com/spendb/angular-cubes/commit/334a15d2dc961fd0214accc28a44a27c7b0d5377
Adding karma back into travis.yml 